### PR TITLE
 Remove word count sorting options from Topics page

### DIFF
--- a/src/components/MarkdownCMS.tsx
+++ b/src/components/MarkdownCMS.tsx
@@ -37,7 +37,7 @@ interface Topic {
   collectionIds?: string[];
 }
 
-type SortOption = 'newest' | 'oldest' | 'az' | 'za' | 'longest' | 'shortest';
+type SortOption = 'newest' | 'oldest' | 'az' | 'za' ;
 
 const EditorWithPreview = ({
   content,
@@ -254,8 +254,6 @@ const EditorWithPreview = ({
       { value: 'oldest', label: 'Oldest First', icon: CalendarDays },
       { value: 'az', label: 'A-Z', icon: ArrowDownAZ },
       { value: 'za', label: 'Z-A', icon: ArrowUpAZ },
-      { value: 'longest', label: 'Longest First', icon: TextQuote },
-      { value: 'shortest', label: 'Shortest First', icon: TextQuote },
     ];
   
     const sortedTopics = useMemo(() => {
@@ -271,10 +269,6 @@ const EditorWithPreview = ({
           return sorted.sort((a, b) => a.name.localeCompare(b.name));
         case 'za':
           return sorted.sort((a, b) => b.name.localeCompare(a.name));
-        case 'longest':
-          return sorted.sort((a, b) => getWordCount(b.content) - getWordCount(a.content));
-        case 'shortest':
-          return sorted.sort((a, b) => getWordCount(a.content) - getWordCount(b.content));
         default:
           return sorted;
       }


### PR DESCRIPTION
## What's Changed
- Removed "Longest First" and "Shortest First" sorting options from the Topics page due to runtime errors
- Simplified the sort options to focus on core functionality: date-based and alphabetical sorting
- Updated TypeScript types to reflect the reduced set of sort options

## Changes in Detail
- Removed 'longest' and 'shortest' from SortOption type definition
- Removed corresponding options from sortOptions array
- Removed related cases from sortedTopics switch statement
- Left getWordCount function in place as it's still used for display purposes in topic cards

## Testing
- Verified that all remaining sort options work as expected:
  - Newest First
  - Oldest First
  - A-Z
  - Z-A
- Confirmed that topic word count still displays correctly in cards

## Why
The word count-based sorting was causing runtime errors and wasn't providing significant value to users. This change simplifies the sorting UI while maintaining the most useful sorting capabilities.