### PR TITLE
Embed media

### DIFF
--- a/src/components/editor/cards/URLDetectorPopup.tsx
+++ b/src/components/editor/cards/URLDetectorPopup.tsx
@@ -1,13 +1,6 @@
-// components/editor/cards/URLDetectorPopup.tsx
-
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import { CardDefinition } from './types';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/components/ui/popover";
 
 interface URLDetectorPopupProps {
   cardType: CardDefinition;
@@ -32,35 +25,15 @@ export function URLDetectorPopup({
         top: `${position.y}px` 
       }}
     >
-      <Popover>
-        <PopoverTrigger asChild>
-          <Button
-            size="sm"
-            variant="outline"
-            className="bg-white dark:bg-slate-800 shadow-md"
-          >
-            <Icon className="h-4 w-4 mr-2" />
-            Transform to {cardType.name}
-          </Button>
-        </PopoverTrigger>
-        <PopoverContent className="w-72">
-          <div className="space-y-2">
-            <h4 className="font-medium">Convert to {cardType.name}</h4>
-            <p className="text-sm text-slate-500">
-              This URL will be transformed into an embedded {cardType.name.toLowerCase()} card.
-            </p>
-            <div className="flex justify-end space-x-2">
-              <Button
-                size="sm"
-                variant="outline"
-                onClick={() => onTransform()}
-              >
-                Transform
-              </Button>
-            </div>
-          </div>
-        </PopoverContent>
-      </Popover>
+      <Button
+        size="sm"
+        variant="outline"
+        onClick={onTransform}
+        className="bg-white dark:bg-slate-800 shadow-md"
+      >
+        <Icon className="h-4 w-4 mr-2" />
+        Convert to {cardType.name}
+      </Button>
     </div>
   );
 }


### PR DESCRIPTION
# Add card embeds for rich media

## Overview
Adds support for rich media embeds (YouTube, Spotify) using a card-based system. This allows users to paste URLs and convert them into rich embeds with a single click.

## Key Features
- Automatic URL detection for supported platforms
- Simple one-click conversion from URL to embed
- Support for YouTube and Spotify initially
- Works in both Write mode and Topic editor
- Clean markdown syntax using `{% type data %}` format

## Implementation Details
Created a card system with:
- Registry for managing card types
- URL detection and transformation
- Card preview rendering in the editor
- Automatic popup for URL conversion

## Files Changed
- Added new files:
  - `components/editor/cards/types.ts`
  - `components/editor/cards/registry.ts`
  - `components/editor/cards/transforms.ts`
  - `components/editor/cards/urlDetectorExtension.ts`
  - `components/editor/cards/URLDetectorPopup.tsx`
  - `components/editor/cards/index.ts`
  - `components/editor/cards/youtube/index.tsx`
  - `components/editor/cards/spotify/index.tsx`

- Modified:
  - `components/editor/MarkdownEditor.tsx`
  - `components/editor/WriteMode.tsx`

## Testing
1. **YouTube Embedding**
   - Paste a YouTube URL
   - Click "Convert to YouTube Video" button
   - Verify embed appears in preview

2. **Spotify Embedding**
   - Paste a Spotify URL
   - Click "Convert to Spotify" button
   - Verify embed appears in preview


## Next Steps
Future improvements could include:
- Support for more platforms 
- HTML sanitization for previews
- Better error handling for invalid URLs
- Loading states for embeds

## Related Issues
Closes #58 