### PR TITLE
Fixed campaign publishing and added hashnode/dev

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -84,11 +84,13 @@ model PublishingPlan {
   id          String    @id @default(auto()) @map("_id") @db.ObjectId
   campaignId  String    @db.ObjectId
   topicId     String    @db.ObjectId
-  platform    String    // 'hashnode', 'devto', 'medium', etc.
-  status      String    @default("scheduled") // scheduled, published, failed
+  platform    String    
+  status      String    @default("scheduled") 
   scheduledFor DateTime?
   publishedAt DateTime?
   publishedUrl String?
+  hashnodeUrl String?  // Add this
+  devToUrl    String?  // Add this
   campaign    Campaign  @relation(fields: [campaignId], references: [id])
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt

--- a/src/app/api/publish/devto/route.ts
+++ b/src/app/api/publish/devto/route.ts
@@ -1,30 +1,60 @@
 import { NextResponse } from 'next/server';
+import { prisma } from '@/lib/prisma';
 
-export async function POST(request: Request) {
+export async function POST(req: Request) {
   try {
-    const { article, apiKey } = await request.json();
+    const { type, itemId, article, apiKey } = await req.json();
 
+    if (!apiKey) {
+      return NextResponse.json(
+        { error: 'Dev.to API token is required' },
+        { status: 400 }
+      );
+    }
+
+    // Publish to Dev.to
     const response = await fetch('https://dev.to/api/articles', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'api-key': apiKey,
-        'Accept': 'application/vnd.forem.api-v1+json'
+        'api-key': apiKey
       },
       body: JSON.stringify(article)
     });
 
     if (!response.ok) {
-      const error = await response.json();
-      return NextResponse.json(error, { status: response.status });
+      const error = await response.text();
+      throw new Error(`Failed to publish to Dev.to: ${error}`);
     }
 
-    const data = await response.json();
-    return NextResponse.json(data);
+    const devToData = await response.json();
+    const url = devToData.url;
+
+    // Update the appropriate record based on type
+    if (type === 'collection') {
+      await prisma.collections.update({
+        where: { id: itemId },
+        data: { devToUrl: url }
+      });
+    } else if (type === 'publishingPlan') {
+      await prisma.publishingPlan.update({
+        where: { id: itemId },
+        data: {
+          devToUrl: url,
+          publishedUrl: url,
+          status: 'published',
+          publishedAt: new Date()
+        }
+      });
+    } else {
+      throw new Error('Invalid publication type');
+    }
+
+    return NextResponse.json({ url });
   } catch (error) {
-    console.error('Failed to publish to Dev.to:', error);
+    console.error('Dev.to publishing error:', error);
     return NextResponse.json(
-      { error: 'Failed to publish to Dev.to' },
+      { error: error instanceof Error ? error.message : 'Failed to publish to Dev.to' },
       { status: 500 }
     );
   }

--- a/src/app/api/publishing-plans/[id]/route.ts
+++ b/src/app/api/publishing-plans/[id]/route.ts
@@ -21,13 +21,15 @@ export async function DELETE(
   }
 }
 
-export async function PATCH(
+export async function PUT(
   request: NextRequest,
   context: { params: Promise<{ id: string }> }
 ) {
   const { id } = await context.params;
   try {
     const body = await request.json();
+    console.log('Updating publishing plan:', { id, body });  // Add debug log
+    
     const publishingPlan = await prisma.publishingPlan.update({
       where: { id },
       data: {
@@ -40,7 +42,7 @@ export async function PATCH(
   } catch (error) {
     console.error('Error updating publishing plan:', error);
     return NextResponse.json(
-      { error: 'Internal error' }, 
+      { error: error instanceof Error ? error.message : 'Internal error' }, 
       { status: 500 }
     );
   }

--- a/src/components/Collections.tsx
+++ b/src/components/Collections.tsx
@@ -61,7 +61,6 @@ interface Topic {
   collectionIds?: string[];
 }
 
-
 interface Collection {
   id: string;
   name: string;
@@ -81,6 +80,7 @@ interface SortableTopicItemProps {
   onToggle: (id: string) => void;
   onRemove: (id: string) => void;
 }
+
 const SortableTopicItem = ({ id, topic, isSelected, onToggle, onRemove }: SortableTopicItemProps) => {
   const {
     attributes,
@@ -177,7 +177,6 @@ export default function Collections() {
       coordinateGetter: sortableKeyboardCoordinates,
     })
   );
-
   // Fetch collections with metrics
   useEffect(() => {
     fetchCollections();
@@ -188,9 +187,8 @@ export default function Collections() {
   }, []);
 
   const fetchCollections = () => {
-    return refreshCollections();  // Use the refreshCollections function from useCollections hook
+    return refreshCollections();
   };
-
 
   const markdownToHtml = (markdown: string): string => {
     return markdown
@@ -343,7 +341,6 @@ export default function Collections() {
 
   const handleSocialShare = async (collection: Collection, platform: PlatformId) => {
     try {
-      // Track the social share attempt first
       await fetch('/api/social/metrics', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -353,7 +350,6 @@ export default function Collections() {
         })
       });
   
-      // Handle web intent platforms differently
       if (PLATFORMS[platform].webIntent) {
         shareViaWebIntent(platform as 'threads', {
           text: collection.name,
@@ -362,7 +358,6 @@ export default function Collections() {
         return;
       }
   
-      // Social client code for Bluesky and Mastodon
       setSelectedPlatform(platform);
       setPublishingCollection(collection);
       setShowSocialPublisher(true);
@@ -490,7 +485,6 @@ export default function Collections() {
       </Layout>
     );
   }
-
   return (
     <Layout pathname={pathname}>
       {/* Header */}
@@ -679,7 +673,10 @@ export default function Collections() {
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
           <div className="max-w-md w-full bg-[#1c1c1e] rounded-lg shadow-xl">
             <HashnodePublisher
-              collection={publishingCollection}
+              type="collection"
+              itemId={publishingCollection.id}
+              name={publishingCollection.name}
+              description={publishingCollection.description}
               content={generateCollectionHTML(publishingCollection)}
               onSuccess={(url: string) => {
                 setShowHashnodePublisher(false);
@@ -700,7 +697,10 @@ export default function Collections() {
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
           <div className="max-w-md w-full bg-[#1c1c1e] rounded-lg shadow-xl">
             <DevToPublisher
-              collection={publishingCollection}
+              type="collection"
+              itemId={publishingCollection.id}
+              name={publishingCollection.name}
+              description={publishingCollection.description}
               content={generateCollectionHTML(publishingCollection)}
               rawMarkdown={generateCollectionMarkdown(publishingCollection)}
               onSuccess={(url: string) => {

--- a/src/components/DevToPublisher.tsx
+++ b/src/components/DevToPublisher.tsx
@@ -9,13 +9,10 @@ import { AlertCircle } from 'lucide-react';
 import { useDevToSettings } from '@/hooks/useDevToSettings';
 
 interface DevToPublisherProps {
-  collection: {
-    id: string;
-    name: string;
-    description?: string;
-    topicIds: string[];
-  };
-  // We'll now get both HTML and Markdown content
+  type: 'collection' | 'publishingPlan';
+  itemId: string;
+  name: string;
+  description?: string;
   content: string;
   rawMarkdown: string;
   onSuccess: (url: string) => void;
@@ -23,7 +20,10 @@ interface DevToPublisherProps {
 }
 
 export function DevToPublisher({
-  collection,
+  type,
+  itemId,
+  name,
+  description,
   content,
   rawMarkdown,
   onSuccess,
@@ -31,7 +31,6 @@ export function DevToPublisher({
 }: DevToPublisherProps) {
   const { getSettings } = useDevToSettings();
   const savedSettings = getSettings();
-  const [apiKey, setApiKey] = useState(savedSettings.token);
   const [published, setPublished] = useState(false);
   const [tags, setTags] = useState('bebop');
   const [status, setStatus] = useState<{ type: 'error' | 'success' | ''; message: string }>({
@@ -47,9 +46,9 @@ export function DevToPublisher({
     try {
       const article = {
         article: {
-          title: collection.name,
-          body_markdown: rawMarkdown, // Use the raw Markdown content instead of HTML
-          description: collection.description,
+          title: name,
+          body_markdown: rawMarkdown,
+          description: description,
           published,
           tags: tags.split(',').map(tag => tag.trim()),
           series: 'Bebop CMS'
@@ -68,8 +67,10 @@ export function DevToPublisher({
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
+          type,
+          itemId,
           article,
-          apiKey
+          apiKey: savedSettings.token
         })
       });
 
@@ -87,13 +88,6 @@ export function DevToPublisher({
       setStatus({
         type: 'success',
         message: 'Successfully published to Dev.to!'
-      });
-
-      // Update collection with Dev.to URL
-      await fetch(`/api/collections/${collection.id}/devto`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ devToUrl: data.url })
       });
 
       onSuccess(data.url);


### PR DESCRIPTION


# Add Dev.to and Hashnode publishing to Campaigns

## Changes
- Updated HashnodePublisher and DevToPublisher components to support both Collections and Campaigns via type prop
- Added proper error handling and status updates for campaign publishing
- Fixed API route method mismatch (PUT vs PATCH) for publishing plan updates
- Added debug logging for better error tracking

## Files Changed
- HashnodePublisher.tsx
- DevToPublisher.tsx
- CampaignPlanner.tsx
- app/api/publishing-plans/[id]/route.ts
- hooks/useCampaigns.ts

## Testing
- [x] Can publish individual topics to Dev.to from Campaigns
- [x] Can publish individual topics to Hashnode from Campaigns
- [x] Publishing status updates correctly in UI
- [x] Error handling shows appropriate messages
- [x] Collections publishing still works as before
- [x] Verified all database updates work correctly

## Notes
- Collections and Campaigns now share the same publishing components but handle updates differently based on type
- Added more robust error handling to show when post succeeds but status update fails
- PUT vs PATCH fix resolves the "failed to update status" error

## Breaking Changes
None. All existing functionality remains intact.
